### PR TITLE
Fix command for serving docs locally

### DIFF
--- a/content/contributing/docs.md
+++ b/content/contributing/docs.md
@@ -27,7 +27,7 @@ feature.
 ## Building Docs
 
 To build the docs locally, run `tox r -e docs`. To serve the docs locally, run
-`python -m http.server docs/_build/dirhtml`. Then go to <https://localhost:8000>
+`python -m http.server -d docs/_build/dirhtml`. Then go to <https://localhost:8000>
 in your browser to view the docs.
 
 Documentation is hosted by Read the Docs. It is deployed on every change to the


### PR DESCRIPTION
Nothing major, just a small bug in the command shown to serve the docs of a project after building.

Example, using the click project:

With the current command:

```bash
$ python -m http.server docs/_build/dirhtml

usage: server.py [-h] [--cgi] [-b ADDRESS] [-d DIRECTORY] [-p VERSION] [port]
server.py: error: argument port: invalid int value: 'docs/_build/dirhtml'
```

With the fixed command:

```bash
$ python -m http.server -d docs/_build/dirhtml

Serving HTTP on :: port 8000 (http://[::]:8000/) ...
```